### PR TITLE
Flexible module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,8 @@ This plugin requires passing the following plugin/babel options (besides adding 
 ### Plugin options
 - `globalName` **{string}** The name of the global variable that the modules should be exported to.
 
+default exports will be exported as `globalName.filename` whilst named exports will be exported as
+`globalNameNamed.filename.exportname`.
+
 ### Babel options
 - `filename` **{string}** This is an optional existing babel option, but is required for this plugin, since the plugin uses the file name to decide the name of the keys that will be exported in the global variable.

--- a/README.md
+++ b/README.md
@@ -27,5 +27,9 @@ This plugin requires passing the following plugin/babel options (besides adding 
 default exports will be exported as `globalName.filename` whilst named exports will be exported as
 `globalNameNamed.filename.exportname`.
 
+`globalName` can also be a function that returns the global ID of each exported function.
+e.g. `(state, filePath, name, isWildcard) => 'this.MyModule.Views' + name ? '.' + name : ''`
+
+
 ### Babel options
 - `filename` **{string}** This is an optional existing babel option, but is required for this plugin, since the plugin uses the file name to decide the name of the keys that will be exported in the global variable.

--- a/index.js
+++ b/index.js
@@ -87,17 +87,23 @@ module.exports = function(babel) {
    * @return {!Specifier}
    */
   function getGlobalIdentifier(state, filePath, name, opt_isWildcard) {
-    var globalName = state.opts.globalName;
-    if (name || opt_isWildcard) {
-      globalName += 'Named';
-    }
-
     assertFilenameRequired(state.file.opts.filename);
-    filePath = path.resolve(path.dirname(state.file.opts.filename), filePath);
-    var splitPath = filePath.split(path.sep);
-    var moduleName = splitPath[splitPath.length - 1];
+    var globalName = state.opts.globalName;
+    var id;
+    if (typeof globalName === 'function') {
+        id = globalName(state, filePath, name, opt_isWildcard);
+    }
+    else {
+      if (name || opt_isWildcard) {
+        globalName += 'Named';
+      }
 
-    var id = 'this.' + globalName + '.' + moduleName + (name ? '.' + name : '');
+      filePath = path.resolve(path.dirname(state.file.opts.filename), filePath);
+      var splitPath = filePath.split(path.sep);
+      var moduleName = splitPath[splitPath.length - 1];
+
+      id = 'this.' + globalName + '.' + moduleName + (name ? '.' + name : '');
+    }
 
     return t.identifier(id);
   }


### PR DESCRIPTION
This allows globalName to be a function.

If the globalName is a string, the same behaviour happens as now.
If globalName is a function, it is expected to return the id.

With the existing behaviour, I have two conflicting javascript files models/users.js and views/users.js
One of them overwrites the other.
With globalName as a function, I can change the way the global is named to include 'models' in the key chain.

I debated alternate approaches to this but this seemed the most flexible. I am happy to consider alternatives.

I also added a little documentation on the default 'Named' behaviour.
