### PR TITLE
Fix rewriting export default with function and class declarations 

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,13 @@ module.exports = function(babel) {
       ExportDefaultDeclaration: function(nodePath, state) {
         var replacements = [];
         var id = getGlobalIdentifier(state, getFilenameNoExt(state.file.opts.filename));
-        assignToGlobal(id, replacements, nodePath.node.declaration);
+        var node = nodePath.node;
+        var expression = node.declaration;
+        if (t.isFunctionDeclaration(node.declaration) || t.isClassDeclaration(node.declaration)) {
+          replacements.push(node.declaration);
+          expression = node.declaration.id;
+        }
+        assignToGlobal(id, replacements, expression);
         nodePath.replaceWithMultiple(replacements);
       },
 

--- a/test/test.js
+++ b/test/test.js
@@ -119,6 +119,32 @@ module.exports = {
     test.done();
   },
 
+  testDefaultFunctionDeclarationExport: function(test) {
+    var babelOptions = getBabelOptions(path.resolve('foo/bar.js'));
+    var result = babel.transform('export default function foo() {}', babelOptions);
+
+    var expectedResult = '(function () {\n' +
+      '  function foo() {}\n' +
+      '  this.myGlobal.bar = foo;\n' +
+      '}).call(this);';
+    assert.strictEqual(expectedResult, result.code);
+
+    test.done();
+  },
+
+  testDefaultClassDeclarationExport: function(test) {
+    var babelOptions = getBabelOptions(path.resolve('foo/bar.js'));
+    var result = babel.transform('export default class Foo {}', babelOptions);
+
+    var expectedResult = '(function () {\n' +
+      '  class Foo {}\n' +
+      '  this.myGlobal.bar = Foo;\n' +
+      '}).call(this);';
+    assert.strictEqual(expectedResult, result.code);
+
+    test.done();
+  },
+
   testNamedExport: function(test) {
     var babelOptions = getBabelOptions(path.resolve('foo/bar.js'));
     var result = babel.transform('export {foo, bar}', babelOptions);


### PR DESCRIPTION
Fixes mairatma/babel-globals#6

The following code should now compile properly

``` js
export default function foo() {
  console.log("Hello World!");
}
```
