### PR TITLE
Add support for ignoring non filepath based imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ This is a [babel plugin](https://babeljs.io/docs/advanced/plugins/) that convert
 // Modules will be available at this.myGlobal.
 ```
 
+Import statements will be removed if the imported file is not a relative or absolute path.
+This allows for CDN hosted libraries to be explicitly imported in code whilst still retaining the globals import system.
+
 ## API
 This plugin requires passing the following plugin/babel options (besides adding the plugin):
 

--- a/index.js
+++ b/index.js
@@ -163,17 +163,20 @@ module.exports = function(babel) {
        */
       ImportDeclaration: function(nodePath, state) {
         var replacements = [];
-        nodePath.node.specifiers.forEach(function(specifier) {
-          var expr = getGlobalExpression(
-            state,
-            removeExtensions(nodePath.node.source.value),
-            specifier.imported ? specifier.imported.name : null,
-            t.isImportNamespaceSpecifier(specifier)
-          );
-          replacements.push(t.variableDeclaration('var', [
-            t.variableDeclarator(specifier.local, expr)
-          ]));
-        });
+
+        if ( nodePath.node.source.value.match(/^[\./]/) ) {
+          nodePath.node.specifiers.forEach(function(specifier) {
+            var expr = getGlobalExpression(
+              state,
+              removeExtensions(nodePath.node.source.value),
+              specifier.imported ? specifier.imported.name : null,
+              t.isImportNamespaceSpecifier(specifier)
+            );
+            replacements.push(t.variableDeclaration('var', [
+              t.variableDeclarator(specifier.local, expr)
+            ]));
+          });
+        }
         nodePath.replaceWithMultiple(replacements);
       },
 

--- a/test/test.js
+++ b/test/test.js
@@ -310,6 +310,14 @@ module.exports = {
     assert.strictEqual(expectedResult, result.code);
 
     test.done();
+  },
+
+  testImportWithNonFilePath: function(test) {
+    var result = babel.transform('import foo from "bar"', getBabelOptions());
+    var expected = '(function () {}).call(this);';
+    assert.strictEqual(expected, result.code);
+
+    test.done();
   }
 };
 


### PR DESCRIPTION
This replaces import statements of the form:

``` javascript
import foo from 'bar';
```

where bar is not a relative or absolute file path, with nothing.

If bar starts with . or / it is importing from a file on disk and the
existing behaviour of replacing it with a global is retained.

Fixes #6
